### PR TITLE
Update MarketHunt URL and bump version to 1.4.7

### DIFF
--- a/mh-item-links.user.js
+++ b/mh-item-links.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         🐭️ MouseHunt - Item Links
-// @version      1.4.6
+// @version      1.4.7
 // @description  Add links to the MouseHunt wiki, MHCT looter, MHDB, and Markethunt for items.
 // @license      MIT
 // @author       bradp
@@ -131,7 +131,7 @@
     // Link to markethunt.
     const isTradable = document.querySelectorAll('.itemView-sidebar-checklistItem.checked');
     if (args.forceType === 'marketplace' || (isTradable && isTradable.length === 2)) {
-      newText.innerHTML += makeLink('Markethunt', `https://markethunt.vsong.ca/index.php?item_id=${itemID}`);
+      newText.innerHTML += makeLink('Markethunt', `https://markethunt.win/index.php?item_id=${itemID}`);
     }
 
     return newText;


### PR DESCRIPTION
This commit updates the MarketHunt URL domain name from markethunt.vsong.ca to markethunt.win as the previous value results in a 404. The userscript header-block version is also bumped to 1.4.7